### PR TITLE
Preventing endpoints from creating Products, ProductCategories and Br…

### DIFF
--- a/src/main/java/com/bankly/vendura/inventory/brand/BrandService.java
+++ b/src/main/java/com/bankly/vendura/inventory/brand/BrandService.java
@@ -3,6 +3,7 @@ package com.bankly.vendura.inventory.brand;
 import com.bankly.vendura.inventory.brand.model.Brand;
 import com.bankly.vendura.inventory.brand.model.BrandDTO;
 import com.bankly.vendura.inventory.brand.model.BrandRepository;
+import com.bankly.vendura.utilities.exceptions.EntityCreationException;
 import com.bankly.vendura.utilities.exceptions.EntityRetrieveException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,11 @@ public class BrandService {
   private final BrandRepository brandRepository;
 
   public Brand createBrand(BrandDTO brandDTO) {
+
+    if (this.brandRepository.findByName(brandDTO.getName()).isPresent()) {
+      throw new EntityCreationException(
+          "Brand with that name already exists", HttpStatus.CONFLICT, brandDTO.getName(), false);
+    }
 
     Brand brand = new Brand();
 
@@ -32,6 +38,10 @@ public class BrandService {
                 () -> new EntityRetrieveException("Brand not found", HttpStatus.NOT_FOUND, id));
 
     if (brandDTO.getName() != null) {
+      if (this.brandRepository.findByName(brandDTO.getName()).isPresent()) {
+        throw new EntityCreationException(
+            "Brand with that name already exists", HttpStatus.CONFLICT, brandDTO.getName(), false);
+      }
       brand.setName(brandDTO.getName());
     }
 
@@ -40,10 +50,10 @@ public class BrandService {
 
   public void deleteBrand(String id) {
     Brand brand =
-            this.brandRepository
-                    .findById(id)
-                    .orElseThrow(
-                            () -> new EntityRetrieveException("Brand not found", HttpStatus.NOT_FOUND, id));
+        this.brandRepository
+            .findById(id)
+            .orElseThrow(
+                () -> new EntityRetrieveException("Brand not found", HttpStatus.NOT_FOUND, id));
 
     this.brandRepository.delete(brand);
   }

--- a/src/main/java/com/bankly/vendura/inventory/brand/model/BrandRepository.java
+++ b/src/main/java/com/bankly/vendura/inventory/brand/model/BrandRepository.java
@@ -2,4 +2,10 @@ package com.bankly.vendura.inventory.brand.model;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface BrandRepository extends MongoRepository<Brand, String> {}
+import java.util.Optional;
+
+public interface BrandRepository extends MongoRepository<Brand, String> {
+
+    Optional<Brand> findByName(String name);
+
+}

--- a/src/main/java/com/bankly/vendura/inventory/product/ProductService.java
+++ b/src/main/java/com/bankly/vendura/inventory/product/ProductService.java
@@ -7,6 +7,7 @@ import com.bankly.vendura.inventory.product.model.ProductFactory;
 import com.bankly.vendura.inventory.product.model.ProductRepository;
 import com.bankly.vendura.inventory.productcategory.model.ProductCategoryFactory;
 import com.bankly.vendura.inventory.supplier.model.SupplierFactory;
+import com.bankly.vendura.utilities.exceptions.EntityCreationException;
 import com.bankly.vendura.utilities.exceptions.EntityRetrieveException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,12 @@ public class ProductService {
   private final ProductRepository productRepository;
 
   public Product create(ProductDTO productDTO) {
+
+    if (this.productRepository.findByName(productDTO.getName()).isPresent()) {
+      throw new EntityCreationException(
+              "Product with that name already exists", HttpStatus.CONFLICT, productDTO.getName(), false);
+    }
+
     Product product = ProductFactory.toEntity(productDTO);
     return this.productRepository.save(product);
   }
@@ -32,10 +39,19 @@ public class ProductService {
                 () -> new EntityRetrieveException("Product not found", HttpStatus.NOT_FOUND, id));
 
     if (productDTO.getId() != null) {
+      if (this.productRepository.findById(productDTO.getId()).isPresent()) {
+        throw new EntityCreationException(
+                "Product with that ID already exists", HttpStatus.CONFLICT, productDTO.getName(), false);
+      }
       product.setId(productDTO.getId());
     }
 
     if (productDTO.getName() != null) {
+      if (this.productRepository.findByName(productDTO.getName()).isPresent()) {
+        throw new EntityCreationException(
+                "Product with that name already exists", HttpStatus.CONFLICT, productDTO.getName(), false);
+      }
+
       product.setName(productDTO.getName());
     }
 

--- a/src/main/java/com/bankly/vendura/inventory/product/model/ProductRepository.java
+++ b/src/main/java/com/bankly/vendura/inventory/product/model/ProductRepository.java
@@ -2,4 +2,10 @@ package com.bankly.vendura.inventory.product.model;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface ProductRepository extends MongoRepository<Product, String> {}
+import java.util.Optional;
+
+public interface ProductRepository extends MongoRepository<Product, String> {
+
+    Optional<Product> findByName(String name);
+
+}

--- a/src/main/java/com/bankly/vendura/inventory/productcategory/ProductCategoryService.java
+++ b/src/main/java/com/bankly/vendura/inventory/productcategory/ProductCategoryService.java
@@ -3,6 +3,7 @@ package com.bankly.vendura.inventory.productcategory;
 import com.bankly.vendura.inventory.productcategory.model.ProductCategory;
 import com.bankly.vendura.inventory.productcategory.model.ProductCategoryDTO;
 import com.bankly.vendura.inventory.productcategory.model.ProductCategoryRepository;
+import com.bankly.vendura.utilities.exceptions.EntityCreationException;
 import com.bankly.vendura.utilities.exceptions.EntityRetrieveException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,15 @@ public class ProductCategoryService {
   private final ProductCategoryRepository productCategoryRepository;
 
   public ProductCategory create(ProductCategoryDTO productCategoryDTO) {
+
+    if (this.productCategoryRepository.findByName(productCategoryDTO.getName()).isPresent()) {
+      throw new EntityCreationException(
+          "ProductCategory with that name already exists",
+          HttpStatus.CONFLICT,
+          productCategoryDTO.getName(),
+          false);
+    }
+
     ProductCategory productCategory = new ProductCategory();
     productCategory.setName(productCategoryDTO.getName());
     return this.productCategoryRepository.save(productCategory);
@@ -31,6 +41,15 @@ public class ProductCategoryService {
                         "Product category not found", HttpStatus.NOT_FOUND, id));
 
     if (productCategoryDTO.getName() != null) {
+
+      if (this.productCategoryRepository.findByName(productCategoryDTO.getName()).isPresent()) {
+        throw new EntityCreationException(
+            "ProductCategory with that name already exists",
+            HttpStatus.CONFLICT,
+            productCategoryDTO.getName(),
+            false);
+      }
+
       productCategory.setName(productCategoryDTO.getName());
     }
 

--- a/src/main/java/com/bankly/vendura/inventory/productcategory/model/ProductCategoryRepository.java
+++ b/src/main/java/com/bankly/vendura/inventory/productcategory/model/ProductCategoryRepository.java
@@ -2,4 +2,10 @@ package com.bankly.vendura.inventory.productcategory.model;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface ProductCategoryRepository extends MongoRepository<ProductCategory, String> {}
+import java.util.Optional;
+
+public interface ProductCategoryRepository extends MongoRepository<ProductCategory, String> {
+
+    Optional<ProductCategory> findByName(String name);
+
+}

--- a/src/main/java/com/bankly/vendura/inventory/supplier/SupplierService.java
+++ b/src/main/java/com/bankly/vendura/inventory/supplier/SupplierService.java
@@ -4,6 +4,7 @@ import com.bankly.vendura.inventory.supplier.model.Supplier;
 import com.bankly.vendura.inventory.supplier.model.SupplierDTO;
 import com.bankly.vendura.inventory.supplier.model.SupplierFactory;
 import com.bankly.vendura.inventory.supplier.model.SupplierRepository;
+import com.bankly.vendura.utilities.exceptions.EntityCreationException;
 import com.bankly.vendura.utilities.exceptions.EntityRetrieveException;
 import com.bankly.vendura.utilities.exceptions.EntityUpdateException;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
This PR is a fix on request of @soenkevogelsberg to prevent the creation of
- Brands
- Products
- ProductCategories
with the same name more than once.
Also this prevents the ID change of Products (ID on products is not immutable) on Controller/Service-Level instead of Repository-Level which ensures a consistent error response.